### PR TITLE
fix(playlist): remove album track limit in playlist, fixes #25

### DIFF
--- a/Properties/YouTubePlaylist.cs
+++ b/Properties/YouTubePlaylist.cs
@@ -198,7 +198,7 @@ public class YouTubeMusicExtractor
         // Sort by track number to ensure proper order
         songs = songs.OrderBy(s => s.Number).ToList();
 
-        return songs.Take(20).ToList(); // Reasonable limit for an album
+        return songs.ToList(); // Reasonable limit for an album
     }
 
     // Helper method to sort songs by their appearance order in the original content

--- a/Properties/YouTubePlaylist.cs
+++ b/Properties/YouTubePlaylist.cs
@@ -198,7 +198,7 @@ public class YouTubeMusicExtractor
         // Sort by track number to ensure proper order
         songs = songs.OrderBy(s => s.Number).ToList();
 
-        return songs.ToList(); // Reasonable limit for an album
+        return songs.ToList(); // Removed track limit for an album in 2.6.1
     }
 
     // Helper method to sort songs by their appearance order in the original content


### PR DESCRIPTION
This removes the limit of 20 songs to the playlist. Many compilations, deluxe editions, instrumental and other special albums have more than 20 tracks.